### PR TITLE
upgrade julia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ CEnum = "0.4"
 Colors = "0.12"
 Raylib_jll = "4.0"
 StaticArrays = "1.2"
-julia = "1.6"
+julia = "1.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
RayLib.jl is currently in an early stage of developing, and should only support the latest version of julia. This PR upgrade julia from 1.6 to 1.7. 