### PR TITLE
Add method overloads to convert Julia enums to Ints for input events

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -73,7 +73,7 @@ end
 
 #Convert MouseCursor Enums to Int
 for func in :(
-    SetMouseCursor
+    SetMouseCursor,
 ).args
     @eval Binding.$func(c::MouseCursor) = $func(convert(Integer, c))
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -57,9 +57,23 @@ end
 Base.length(fdata::RayFileData) = length(fdata.data)
 Base.pointer(fdata::RayFileData) = pointer(fdata.data)
 
-
+#Convert KeyPressed Enums to Int
 for func in :(
     IsKeyDown, IsKeyPressed, IsKeyReleased, IsKeyUp
 ).args
     @eval Binding.$func(k::KeyboardKey) = $func(convert(Integer, k))
+end
+
+#Convert MouseButton Enums to Int
+for func in :(
+    IsMouseButtonDown, IsMouseButtonPressed, IsMouseButtonReleased, IsMouseButtonUp
+).args
+    @eval Binding.$func(m::MouseButton) = $func(convert(Integer, m))
+end
+
+#Convert MouseCursor Enums to Int
+for func in :(
+    SetMouseCursor
+).args
+    @eval Binding.$func(c::MouseCursor) = $func(convert(Integer, c))
 end


### PR DESCRIPTION
Closes #29 and also adds the necessary methods for a few other inputs. More will be needed in the future to eventually cover all Enums representing inputs.